### PR TITLE
Added support for additional view elements

### DIFF
--- a/src/org/itrace/ControlView.java
+++ b/src/org/itrace/ControlView.java
@@ -15,10 +15,9 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IPartListener2;
-import org.eclipse.ui.IViewSite;
-import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
@@ -112,11 +111,8 @@ public class ControlView extends ViewPart implements IPartListener2, EventHandle
     public void partActivated(IWorkbenchPartReference partRef) {
     	if(partRef.getPart(false) instanceof IEditorPart) {
     		ITrace.getDefault().setActiveEditor((IEditorPart)partRef.getPart(false));
-    		IEditorPart ep = (IEditorPart)partRef.getPart(true);
-        	ITrace.getDefault().setLineManager(ep.getEditorSite().getActionBars().getStatusLineManager());
-    	} else {
-			IWorkbenchPart ep = partRef.getPart(true);
-	    	ITrace.getDefault().setLineManager(((IViewSite) ep.getSite()).getActionBars().getStatusLineManager());
+    	} else if(partRef instanceof IViewReference) {
+    		ITrace.getDefault().setActiveViewPart((IViewPart)partRef.getPart(false));
     	}
     }
 
@@ -124,23 +120,17 @@ public class ControlView extends ViewPart implements IPartListener2, EventHandle
     public void partBroughtToTop(IWorkbenchPartReference partRef) {
     	if(partRef.getPart(false) instanceof IEditorPart) {
     		ITrace.getDefault().setActiveEditor((IEditorPart)partRef.getPart(false));
-    		IEditorPart ep = (IEditorPart)partRef.getPart(true);
-        	ITrace.getDefault().setLineManager(ep.getEditorSite().getActionBars().getStatusLineManager());
-    	} else {
-			IWorkbenchPart ep = partRef.getPart(true);
-	    	ITrace.getDefault().setLineManager(((IViewSite) ep.getSite()).getActionBars().getStatusLineManager());
+    	} else if(partRef instanceof IViewReference) {
+    		ITrace.getDefault().setActiveViewPart((IViewPart)partRef.getPart(false));
     	}
     }
 
     @Override
     public void partClosed(IWorkbenchPartReference partRef) {
-    	if(partRef instanceof IEditorReference){
-    		ITrace.getDefault().setActionBars(getViewSite().getActionBars());
-        	IEditorPart editorPart = (IEditorPart)partRef.getPart(true);
-        	ITrace.getDefault().removeEditor(editorPart);
-        	
-        	IEditorPart activeEditor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
-        	ITrace.getDefault().setActiveEditor(activeEditor);
+    	if(partRef.getPart(false) instanceof IEditorPart) {
+    		ITrace.getDefault().removeEditor((IEditorPart)partRef.getPart(false));
+    	} else if(partRef instanceof IViewReference) {
+    		ITrace.getDefault().removeViewPart((IViewPart)partRef.getPart(false));
     	}
     }
 

--- a/src/org/itrace/gaze/handlers/IGazeHandler.java
+++ b/src/org/itrace/gaze/handlers/IGazeHandler.java
@@ -11,12 +11,18 @@ import org.itrace.gaze.IGazeResponse;
  */
 public interface IGazeHandler {
 
+	/**
+	 * Determines whether the gaze is within the boundaries of the
+	 * target object. Return value will be true if the gaze is contained
+	 * within the target object 
+	 */
+	public boolean containsGaze(int absoluteX, int absoluteY);
+	
     /**
      * Handles the specified gaze at the specified x and y coordinates relative
      * to the target object. Return value may be null if the gaze is not
      * meaningful to the target.
      */
-    public IGazeResponse handleGaze(int absoluteX, int absoluteY,
-            int relativeX, int relativeY, Gaze gaze);
+    public IGazeResponse handleGaze(int absoluteX, int absoluteY, Gaze gaze);
     
 }

--- a/src/org/itrace/gaze/handlers/ProjectExplorerGazeHandler.java
+++ b/src/org/itrace/gaze/handlers/ProjectExplorerGazeHandler.java
@@ -1,0 +1,63 @@
+package org.itrace.gaze.handlers;
+
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.IViewPart;
+import org.itrace.Gaze;
+import org.itrace.gaze.IGazeResponse;
+
+public class ProjectExplorerGazeHandler implements IGazeHandler {
+	private String name;	
+    private Tree tree;
+
+    public ProjectExplorerGazeHandler(Tree target, IViewPart partRef) {	
+        this.name = partRef.getTitle();	
+        this.tree = (Tree) target;	
+    }
+    
+    @Override
+    public boolean containsGaze(int absoluteX, int absoluteY) {
+		Rectangle viewScreenBounds = tree.getBounds();
+		Point screenPos = tree.toDisplay(0, 0);
+		viewScreenBounds.x = screenPos.x;
+		viewScreenBounds.y = screenPos.y;
+		
+		if (tree.isVisible() && viewScreenBounds.contains(absoluteX, absoluteY)) {
+			return true;
+	    }
+	    else {
+	    	return false;
+	    }
+    }
+
+    @Override	
+    public IGazeResponse handleGaze(int absoluteX, int absoluteY, final Gaze gaze) {
+    	int relativeX = absoluteX - tree.toDisplay(0, 0).x;
+    	int relativeY = absoluteY - tree.toDisplay(0, 0).y;
+    	
+    	tree.getItem(new Point(relativeX, relativeY));
+        return new IGazeResponse() {	
+            @Override	
+            public String getName() {	
+                return name;	
+            }	
+
+            @Override
+            public Gaze getGaze() {	
+                return gaze;	
+            }	
+
+            @Override	
+            public IGazeHandler getGazeHandler() {	
+                return ProjectExplorerGazeHandler.this;	
+            }	
+
+            @Override	
+            public String getGazeType() {	
+                // TODO Auto-generated method stub	
+                return "view_part";	
+            }	
+        };	
+    }
+}

--- a/src/org/itrace/gaze/handlers/StyledTextGazeHandler.java
+++ b/src/org/itrace/gaze/handlers/StyledTextGazeHandler.java
@@ -7,6 +7,7 @@ import org.eclipse.jface.text.source.projection.ProjectionViewer;
 //import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.itrace.Gaze;
@@ -28,9 +29,24 @@ public class StyledTextGazeHandler implements IGazeHandler {
         this.editor = editor;
         projectionViewer = (ProjectionViewer) editor.getAdapter(ITextOperationTarget.class);
     }
+    
+    @Override
+    public boolean containsGaze(int absoluteX, int absoluteY) {
+    	Rectangle viewScreenBounds = targetStyledText.getBounds();
+		Point screenPos = targetStyledText.toDisplay(0, 0);
+		viewScreenBounds.x = screenPos.x;
+		viewScreenBounds.y = screenPos.y;
+	
+		if (targetStyledText.isVisible() && viewScreenBounds.contains(absoluteX, absoluteY)) {
+			return true;
+	    }
+	    else {
+	    	return false;
+	    }	    	
+    }
 
     @Override
-    public IStyledTextGazeResponse handleGaze(int absoluteX, int absoluteY, int relativeX, int relativeY, final Gaze gaze) {
+    public IStyledTextGazeResponse handleGaze(int absoluteX, int absoluteY, final Gaze gaze) {
         final int lineIndex;
         final int col;
         final Point absoluteLineAnchorPosition;
@@ -40,6 +56,9 @@ public class StyledTextGazeHandler implements IGazeHandler {
         final String path;
 
         try {
+        	int relativeX = absoluteX - targetStyledText.toDisplay(0, 0).x;
+        	int relativeY = absoluteY - targetStyledText.toDisplay(0, 0).y;
+        	
             // Get the actual offset of the current line from the top
             // Allows code folding to be taken into account
             int foldedLineIndex = targetStyledText.getLineIndex(relativeY);

--- a/src/org/itrace/gaze/handlers/WorkbenchGazeHandler.java
+++ b/src/org/itrace/gaze/handlers/WorkbenchGazeHandler.java
@@ -1,0 +1,114 @@
+package org.itrace.gaze.handlers;
+
+import java.util.HashMap;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.itrace.Gaze;
+import org.itrace.ITrace;
+import org.itrace.gaze.IGazeResponse;
+
+public class WorkbenchGazeHandler implements IGazeHandler {
+	protected IWorkbench workbench;
+
+	protected HashMap<IWorkbenchPart, IGazeHandler> partHandlers = new HashMap<IWorkbenchPart, IGazeHandler>();
+
+    public WorkbenchGazeHandler(IWorkbench workbench) {
+    	this.workbench = workbench;
+    	
+    	IWorkbenchPage page = this.workbench.getActiveWorkbenchWindow().getActivePage();
+    	for(IViewReference viewRef : page.getViewReferences()) {
+    		IViewPart viewPart = (IViewPart)viewRef.getPart(true);
+    		if(viewPart != null) {
+    			this.addViewPart(viewPart);
+    		}
+    	}
+    	for(IEditorReference editorRef : page.getEditorReferences()) {
+    		IEditorPart editorPart = (IEditorPart)editorRef.getPart(true);
+    		if(editorPart != null) {
+    			this.addEditor(editorPart);
+    		}
+    	}
+    }
+
+	@Override
+	public boolean containsGaze(int absoluteX, int absoluteY) {
+		Rectangle viewScreenBounds = workbench.getActiveWorkbenchWindow().getShell().getBounds();
+		Point screenPos = workbench.getActiveWorkbenchWindow().getShell().toDisplay(0, 0);
+		viewScreenBounds.x = screenPos.x;
+		viewScreenBounds.y = screenPos.y;
+				
+		if (workbench.getActiveWorkbenchWindow().getShell().isVisible() && viewScreenBounds.contains(absoluteX, absoluteY)) {
+			return true;
+	    }
+	    else {
+			// Needed to handle the case of a workbench part being in a different shell
+			// A simple bounds check of the root shell fails to find it
+			for(IWorkbenchPart part : this.partHandlers.keySet()) {
+				if(this.partHandlers.get(part).containsGaze(absoluteX, absoluteY)) {
+					return true;
+				}
+			}
+	    	return false;
+	    }
+	}
+
+    @Override	
+    public IGazeResponse handleGaze(int absoluteX, int absoluteY, final Gaze gaze) {
+    	for(IWorkbenchPart part : this.partHandlers.keySet()) {
+			if(this.partHandlers.get(part).containsGaze(absoluteX, absoluteY)) {
+				return this.partHandlers.get(part).handleGaze(absoluteX, absoluteY, gaze);
+			}
+		}
+    	
+        return null;	
+    }
+    
+
+	public void addEditor(IEditorPart editorPart) {
+		if (!partHandlers.containsKey(editorPart)) {
+			StyledText styledText = (StyledText) editorPart.getAdapter(Control.class);
+			if (styledText != null) {
+				partHandlers.put(editorPart, new StyledTextGazeHandler(styledText, editorPart));
+			}
+		}
+	}
+
+	public void removeEditor(IEditorPart editorPart) {
+		partHandlers.remove(editorPart);
+		ITrace.getDefault().removeEditor(editorPart);
+	}
+	
+	public void addViewPart(IViewPart viewPart) {
+		if(!partHandlers.containsKey(viewPart)) {
+			if(viewPart instanceof ProjectExplorer) {
+				ProjectExplorer projectExplorerPart = (ProjectExplorer)viewPart;
+				Tree target = (Tree) projectExplorerPart.getCommonViewer().getControl();
+				partHandlers.put(viewPart, new ProjectExplorerGazeHandler(target, viewPart));
+			}
+		}
+	}
+	
+	public void removeViewPart(IViewPart viewPart) {
+		partHandlers.remove(viewPart);
+	}
+	
+	public void dispose() {
+		for(IWorkbenchPart part : partHandlers.keySet()) {			
+			if(part instanceof IEditorPart) {
+				ITrace.getDefault().removeEditor((IEditorPart)part);				
+			}
+		}
+	}
+}


### PR DESCRIPTION
-Added a workbenchGazeHandler to recursively keep track of editors and views and their respective gaze handlers.
-Added a projectExplorerGazeHandler
-Additional views types can now be tracked and managed inside the workbenchGazeHandler
Fixes Issue #17 